### PR TITLE
Fixing directory path in MakeBlockCommand

### DIFF
--- a/src/Commands/MakeBlockCommand.php
+++ b/src/Commands/MakeBlockCommand.php
@@ -40,12 +40,12 @@ class MakeBlockCommand extends Command
 
     public function getBlockSourceFilePath()
     {
-        return base_path('App/DropBlockEditor/Blocks').'/'.$this->getSingularClassName($this->argument('name')).'.php';
+        return base_path('app/DropBlockEditor/Blocks').'/'.$this->getSingularClassName($this->argument('name')).'.php';
     }
 
     public function getEditComponentSourceFilePath()
     {
-        return base_path('App/Http/Livewire').'/'.$this->getSingularClassName($this->argument('name')).'.php';
+        return base_path('app/Http/Livewire').'/'.$this->getSingularClassName($this->argument('name')).'.php';
     }
 
     public function handle(): int


### PR DESCRIPTION
Hi,

I've made some changes to the MakeBlockCommand class to fix an issue with the directory path when creating editor blocks in Laravel. The original implementation was incompatible with Laravel's folder structure, causing the duplication of the app directory. To resolve this, I updated the getBlockSourceFilePath() and getEditComponentSourceFilePath() functions to use the correct folder structure.

Here are the changes I made:

Replaced App with app in the directory paths within the mentioned functions.
This fix ensures that the command now properly creates the block files in the correct directory, in accordance with Laravel's autoload configuration defined in the composer.json file: 
`"autoload": {
    "psr-4": {
        "App\\": "app/",
        "Database\\Factories\\": "database/factories/",
        "Database\\Seeders\\": "database/seeders/"
    }
}`