### PR TITLE
Add block events to allow hooking of data

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,28 +2,35 @@ name: run-tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        laravel: ['10.*', '11.*', '12.*']
         stability: [prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 12.*
+            testbench: 10.*
         exclude:
-           - php: 8.1
-             laravel: 11.*
+          - php: 8.1
+            laravel: 11.*
+          - laravel: 12.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
         "livewire/livewire": "^3.3",
         "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "pestphp/pest": "^2.34|^3.7",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.1",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^10.4",
+        "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+        "phpstan/phpstan-phpunit": "^1.0|^2.0",
+        "phpunit/phpunit": "^10.4|^11.5.3",
         "spatie/laravel-ray": "^1.28",
         "spatie/x-ray": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "livewire/livewire": "^3.3",
+        "livewire/livewire": "^3.3 || ^4.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "livewire/livewire": "^3.3 || ^4.0",
+        "livewire/livewire": "^3.3|^4.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "livewire/livewire": "^3.3|^4.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },

--- a/public/editor.js
+++ b/public/editor.js
@@ -1,1 +1,386 @@
-(()=>{var e,t={254:()=>{function e(e){return function(e){if(Array.isArray(e))return t(e)}(e)||function(e){if("undefined"!=typeof Symbol&&null!=e[Symbol.iterator]||null!=e["@@iterator"])return Array.from(e)}(e)||function(e,r){if(!e)return;if("string"==typeof e)return t(e,r);var n=Object.prototype.toString.call(e).slice(8,-1);"Object"===n&&e.constructor&&(n=e.constructor.name);if("Map"===n||"Set"===n)return Array.from(e);if("Arguments"===n||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n))return t(e,r)}(e)||function(){throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}()}function t(e,t){(null==t||t>e.length)&&(t=e.length);for(var r=0,n=new Array(t);r<t;r++)n[r]=e[r];return n}window.dropblockeditor=function(t){return{iframe:null,dropList:null,insert:!1,device:"desktop",lastTopPos:0,cursorPos:0,currentDragItem:null,insertBeforeClasses:["after:opacity-100","after:top-0","after:h-[5px]"],insertAfterClasses:["after:opacity-100","after:bottom-0","after:h-[5px]"],init:function(){var e=this;this.iframe=document.getElementById("frame"),this.dropList=document.querySelector("[drop-list]"),document.addEventListener("keydown",(function(t){return e.undo(t,e)})),document.addEventListener("keydown",(function(t){return e.redo(t,e)})),this.initListeners(),this.iframe.addEventListener("load",(function(){e.initListeners(),e.iframe.contentWindow.scrollTo(0,e.lastTopPos)}))},initListeners:function(){var t=this,r=this.iframe.contentWindow.document;r.addEventListener("keydown",(function(e){return t.undo(e,t)})),r.addEventListener("keydown",(function(e){return t.redo(e,t)})),this.dropList.querySelectorAll("[drag-item]").forEach((function(e){e.addEventListener("dragstart",(function(e){e.target.setAttribute("inserting",!0)})),e.addEventListener("dragend",(function(e){e.target.removeAttribute("inserting")})),e.addEventListener("dragover",(function(e){return e.preventDefault()}))})),r.querySelectorAll("[drop-placeholder]").forEach((function(e){e.addEventListener("dragover",(function(e){return e.preventDefault()})),e.addEventListener("dragenter",(function(e){e.preventDefault(),e.target.classList.add("bg-gray-200/50","animate-pulse")})),e.addEventListener("dragleave",(function(e){e.preventDefault(),e.target.classList.remove("bg-gray-200/50","animate-pulse")})),e.addEventListener("drop",(function(e){if(e.preventDefault,e.target.closest("[drop-placeholder]")){var r=document.querySelector("[inserting]");return null!=r?(t.component().call("insertBlock",r.dataset.block,0),r.removeAttribute("inserting"),void(r=!1)):void 0}}))})),r.querySelectorAll("[drag-item]").forEach((function(n){n.addEventListener("click",(function(e){Livewire.dispatch("blockEditComponentSelected",{blockId:e.target.closest("[drag-item]").dataset.block})}),!1),n.addEventListener("dragstart",(function(e){e.target.setAttribute("dragging",!0),t.currentDragItem=n})),n.addEventListener("dragover",(function(r){r.preventDefault();var n=r.target.closest("[drag-item]");if(t.currentDragItem!==n){var a,i,o=t.beforeOrAfterEl(r,n),s=null!=t.currentDragItem&&t.currentDragItem.previousElementSibling;if(n!=(null!=t.currentDragItem&&t.currentDragItem.nextElementSibling)&&"before"===o)(a=n.classList).remove.apply(a,e(t.insertAfterClasses)),(i=n.classList).add.apply(i,e(t.insertBeforeClasses));else if(n!=s&&"after"===o){var l,c;(l=n.classList).remove.apply(l,e(t.insertBeforeClasses)),(c=n.classList).add.apply(c,e(t.insertAfterClasses))}else{var d;(d=n.classList).remove.apply(d,e(t.insertBeforeClasses).concat(e(t.insertAfterClasses)))}}})),n.addEventListener("dragend",(function(e){e.target.removeAttribute("dragging"),t.currentDragItem=null})),n.addEventListener("dragenter",(function(e){e.target.hasAttribute("drag-item")&&e.target.setAttribute("is-target",!0)})),n.addEventListener("dragleave",(function(r){var n;(r.preventDefault,r.target.hasAttribute("is-target"))&&(n=r.target.classList).remove.apply(n,e(t.insertAfterClasses).concat(e(t.insertBeforeClasses)))})),n.addEventListener("drop",(function(n){n.preventDefault;var a=r.querySelector("[dragging]"),i=document.querySelector("[inserting]");if(n.target.closest("[drag-item]")){var o;if(n.target.hasAttribute("drag-item"))(o=n.target.classList).remove.apply(o,e(t.insertAfterClasses).concat(e(t.insertBeforeClasses)));t.lastTopPos=r.documentElement.scrollTop;var s=t.beforeOrAfterEl(n,n.target.closest("[drag-item]"));if(null!=i)return t.component().call("insertBlock",i.dataset.block,n.target.closest("[drag-item]").dataset.block,s),i.removeAttribute("inserting"),void(i=!1);"after"===s?n.target.closest("[drag-item]").after(a):n.target.closest("[drag-item]").before(a);var l=Array.from(r.querySelectorAll("[drag-item]")).map((function(e){return e.dataset.block}));t.component().call("reorder",l)}}))}))},isBefore:function(e,t,r){var n=!1,a=!1,i=!1;return e.querySelectorAll("[drag-item]").forEach((function(e){i||(a=!!a||e==r,!1!==(n=!!n||e==t)||!0!==a||(i=!0))})),i},beforeOrAfterEl:function(e,t){var r=t.getBoundingClientRect(),n=r.y,a=n+r.height/2,i=a,o=i+r.height/2,s=e.clientY>=n&&e.clientY<=a,l=e.clientY>=i&&e.clientY<=o;return s?"before":!!l&&"after"},component:function(){return Livewire.find(frame.closest("[wire\\:id]").getAttribute("wire:id"))},undo:function(e,t){!e.ctrlKey&&!e.metaKey||e.shiftKey||"z"!==e.key||(e.preventDefault(),-1!=navigator.userAgent.indexOf("Safari")&&-1==navigator.userAgent.indexOf("Chrome")&&window.history.forward(),t.component().call("undo"))},redo:function(e,t){(e.ctrlKey||e.metaKey)&&e.shiftKey&&"z"===e.key&&(e.preventDefault(),-1!=navigator.userAgent.indexOf("Safari")&&-1==navigator.userAgent.indexOf("Chrome")&&window.history.forward(),t.component().call("redo"))}}}},279:()=>{}},r={};function n(e){var a=r[e];if(void 0!==a)return a.exports;var i=r[e]={exports:{}};return t[e](i,i.exports,n),i.exports}n.m=t,e=[],n.O=(t,r,a,i)=>{if(!r){var o=1/0;for(d=0;d<e.length;d++){for(var[r,a,i]=e[d],s=!0,l=0;l<r.length;l++)(!1&i||o>=i)&&Object.keys(n.O).every((e=>n.O[e](r[l])))?r.splice(l--,1):(s=!1,i<o&&(o=i));if(s){e.splice(d--,1);var c=a();void 0!==c&&(t=c)}}return t}i=i||0;for(var d=e.length;d>0&&e[d-1][2]>i;d--)e[d]=e[d-1];e[d]=[r,a,i]},n.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),(()=>{var e={259:0,448:0};n.O.j=t=>0===e[t];var t=(t,r)=>{var a,i,[o,s,l]=r,c=0;if(o.some((t=>0!==e[t]))){for(a in s)n.o(s,a)&&(n.m[a]=s[a]);if(l)var d=l(n)}for(t&&t(r);c<o.length;c++)i=o[c],n.o(e,i)&&e[i]&&e[i][0](),e[i]=0;return n.O(d)},r=self.webpackChunk=self.webpackChunk||[];r.forEach(t.bind(null,0)),r.push=t.bind(null,r.push.bind(r))})(),n.O(void 0,[448],(()=>n(254)));var a=n.O(void 0,[448],(()=>n(279)));a=n.O(a)})();
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ "./resources/js/editor.js":
+/*!********************************!*\
+  !*** ./resources/js/editor.js ***!
+  \********************************/
+/***/ (() => {
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread(); }
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+window.dropblockeditor = function (config) {
+  return {
+    iframe: null,
+    dropList: null,
+    insert: false,
+    device: 'desktop',
+    lastTopPos: 0,
+    cursorPos: 0,
+    currentDragItem: null,
+    insertBeforeClasses: ['after:opacity-100', 'after:top-0', 'after:h-[5px]'],
+    insertAfterClasses: ['after:opacity-100', 'after:bottom-0', 'after:h-[5px]'],
+    init: function init() {
+      var _this = this;
+      this.iframe = document.getElementById("frame");
+      this.dropList = document.querySelector("[drop-list]");
+      document.addEventListener('keydown', function (e) {
+        return _this.undo(e, _this);
+      });
+      document.addEventListener('keydown', function (e) {
+        return _this.redo(e, _this);
+      });
+      this.initListeners();
+      this.iframe.addEventListener("load", function () {
+        _this.initListeners();
+        _this.iframe.contentWindow.scrollTo(0, _this.lastTopPos);
+      });
+    },
+    initListeners: function initListeners() {
+      var _this2 = this;
+      var root = this.iframe.contentWindow.document;
+      root.addEventListener('keydown', function (e) {
+        return _this2.undo(e, _this2);
+      });
+      root.addEventListener('keydown', function (e) {
+        return _this2.redo(e, _this2);
+      });
+      this.dropList.querySelectorAll('[drag-item]').forEach(function (el) {
+        el.addEventListener("dragstart", function (e) {
+          e.target.setAttribute('inserting', true);
+        });
+        el.addEventListener('dragend', function (e) {
+          e.target.removeAttribute('inserting');
+        });
+        el.addEventListener('dragover', function (e) {
+          return e.preventDefault();
+        });
+      });
+      root.querySelectorAll('[drop-placeholder]').forEach(function (el) {
+        el.addEventListener('dragover', function (e) {
+          return e.preventDefault();
+        });
+        el.addEventListener('dragenter', function (e) {
+          e.preventDefault();
+          e.target.classList.add('bg-gray-200/50', 'animate-pulse');
+        });
+        el.addEventListener('dragleave', function (e) {
+          e.preventDefault();
+          e.target.classList.remove('bg-gray-200/50', 'animate-pulse');
+        });
+        el.addEventListener('drop', function (e) {
+          e.preventDefault;
+          if (!e.target.closest('[drop-placeholder]')) {
+            return;
+          }
+          var insertingEl = document.querySelector('[inserting]');
+          if (insertingEl != null) {
+            _this2.component().call('insertBlock', insertingEl.dataset.block, 0);
+            insertingEl.removeAttribute('inserting');
+            insertingEl = false;
+            return;
+          }
+        });
+      });
+      root.querySelectorAll('[drag-item]').forEach(function (el) {
+        el.addEventListener('click', function (e) {
+          root.querySelectorAll('[drag-item]').forEach(function (preview) {
+            return preview.classList.remove('block-active');
+          });
+          var clickedBlock = e.target.closest('[drag-item]');
+          clickedBlock.classList.add('block-active');
+          Livewire.dispatch('blockEditComponentSelected', {
+            blockId: e.target.closest('[drag-item]').dataset.block
+          });
+        }, false);
+        el.addEventListener('dragstart', function (e) {
+          e.target.setAttribute('dragging', true);
+          _this2.currentDragItem = el;
+        });
+        el.addEventListener('dragover', function (e) {
+          e.preventDefault();
+          var dragitem = e.target.closest('[drag-item]');
+          if (_this2.currentDragItem === dragitem) {
+            return;
+          }
+          var placement = _this2.beforeOrAfterEl(e, dragitem);
+          var isPreviousSibling = _this2.currentDragItem != null ? _this2.currentDragItem.previousElementSibling : false;
+          var isNextSibling = _this2.currentDragItem != null ? _this2.currentDragItem.nextElementSibling : false;
+          if (dragitem != isNextSibling && placement === 'before') {
+            var _dragitem$classList, _dragitem$classList2;
+            (_dragitem$classList = dragitem.classList).remove.apply(_dragitem$classList, _toConsumableArray(_this2.insertAfterClasses));
+            (_dragitem$classList2 = dragitem.classList).add.apply(_dragitem$classList2, _toConsumableArray(_this2.insertBeforeClasses));
+          } else if (dragitem != isPreviousSibling && placement === 'after') {
+            var _dragitem$classList3, _dragitem$classList4;
+            (_dragitem$classList3 = dragitem.classList).remove.apply(_dragitem$classList3, _toConsumableArray(_this2.insertBeforeClasses));
+            (_dragitem$classList4 = dragitem.classList).add.apply(_dragitem$classList4, _toConsumableArray(_this2.insertAfterClasses));
+          } else {
+            var _dragitem$classList5;
+            (_dragitem$classList5 = dragitem.classList).remove.apply(_dragitem$classList5, _toConsumableArray(_this2.insertBeforeClasses).concat(_toConsumableArray(_this2.insertAfterClasses)));
+          }
+        });
+        el.addEventListener('dragend', function (e) {
+          e.target.removeAttribute('dragging');
+          _this2.currentDragItem = null;
+        });
+        el.addEventListener('dragenter', function (e) {
+          if (e.target.hasAttribute('drag-item')) {
+            e.target.setAttribute('is-target', true);
+          }
+        });
+        el.addEventListener('dragleave', function (e) {
+          e.preventDefault;
+          if (e.target.hasAttribute('is-target')) {
+            var _e$target$classList;
+            (_e$target$classList = e.target.classList).remove.apply(_e$target$classList, _toConsumableArray(_this2.insertAfterClasses).concat(_toConsumableArray(_this2.insertBeforeClasses)));
+          }
+        });
+        el.addEventListener('drop', function (e) {
+          e.preventDefault;
+          var draggingEl = root.querySelector('[dragging]');
+          var insertingEl = document.querySelector('[inserting]');
+          if (!e.target.closest('[drag-item]')) {
+            return;
+          }
+          if (e.target.hasAttribute('drag-item')) {
+            var _e$target$classList2;
+            (_e$target$classList2 = e.target.classList).remove.apply(_e$target$classList2, _toConsumableArray(_this2.insertAfterClasses).concat(_toConsumableArray(_this2.insertBeforeClasses)));
+          }
+          _this2.lastTopPos = root.documentElement.scrollTop;
+          var placement = _this2.beforeOrAfterEl(e, e.target.closest('[drag-item]'));
+          if (insertingEl != null) {
+            _this2.component().call('insertBlock', insertingEl.dataset.block, e.target.closest('[drag-item]').dataset.block, placement);
+            insertingEl.removeAttribute('inserting');
+            insertingEl = false;
+            return;
+          }
+          if (placement === 'after') {
+            e.target.closest('[drag-item]').after(draggingEl);
+          } else {
+            e.target.closest('[drag-item]').before(draggingEl);
+          }
+          var orderIds = Array.from(root.querySelectorAll('[drag-item]')).map(function (itemEl) {
+            return itemEl.dataset.block;
+          });
+          _this2.component().call('reorder', orderIds);
+        });
+      });
+    },
+    isBefore: function isBefore(container, target, current) {
+      var targetFound = false;
+      var currentFound = false;
+      var before = false;
+      container.querySelectorAll('[drag-item]').forEach(function (el) {
+        if (before) {
+          return;
+        }
+        targetFound = targetFound ? true : el == target;
+        currentFound = currentFound ? true : el == current;
+        if (targetFound === false && currentFound === true) {
+          before = true;
+          return;
+        }
+      });
+      return before;
+    },
+    beforeOrAfterEl: function beforeOrAfterEl(e, el) {
+      var bounding = el.getBoundingClientRect();
+      var upperHalfStart = bounding.y;
+      var upperHalfEnd = upperHalfStart + bounding.height / 2;
+      var bottomHalfStart = upperHalfEnd;
+      var bottomHalfEnd = bottomHalfStart + bounding.height / 2;
+      var isTopHalf = e.clientY >= upperHalfStart && e.clientY <= upperHalfEnd;
+      var isBottomHalf = e.clientY >= bottomHalfStart && e.clientY <= bottomHalfEnd;
+      if (isTopHalf) {
+        return 'before';
+      } else if (isBottomHalf) {
+        return 'after';
+      }
+      return false;
+    },
+    component: function component() {
+      return Livewire.find(frame.closest('[wire\\:id]').getAttribute('wire:id'));
+    },
+    undo: function undo(e, editor) {
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+          window.history.forward();
+        }
+        editor.component().call('undo');
+      }
+    },
+    redo: function redo(e, editor) {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+          window.history.forward();
+        }
+        editor.component().call('redo');
+      }
+    }
+  };
+};
+
+/***/ }),
+
+/***/ "./resources/css/editor.css":
+/*!**********************************!*\
+  !*** ./resources/css/editor.css ***!
+  \**********************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+// extracted by mini-css-extract-plugin
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = __webpack_modules__;
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/chunk loaded */
+/******/ 	(() => {
+/******/ 		var deferred = [];
+/******/ 		__webpack_require__.O = (result, chunkIds, fn, priority) => {
+/******/ 			if(chunkIds) {
+/******/ 				priority = priority || 0;
+/******/ 				for(var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--) deferred[i] = deferred[i - 1];
+/******/ 				deferred[i] = [chunkIds, fn, priority];
+/******/ 				return;
+/******/ 			}
+/******/ 			var notFulfilled = Infinity;
+/******/ 			for (var i = 0; i < deferred.length; i++) {
+/******/ 				var [chunkIds, fn, priority] = deferred[i];
+/******/ 				var fulfilled = true;
+/******/ 				for (var j = 0; j < chunkIds.length; j++) {
+/******/ 					if ((priority & 1 === 0 || notFulfilled >= priority) && Object.keys(__webpack_require__.O).every((key) => (__webpack_require__.O[key](chunkIds[j])))) {
+/******/ 						chunkIds.splice(j--, 1);
+/******/ 					} else {
+/******/ 						fulfilled = false;
+/******/ 						if(priority < notFulfilled) notFulfilled = priority;
+/******/ 					}
+/******/ 				}
+/******/ 				if(fulfilled) {
+/******/ 					deferred.splice(i--, 1)
+/******/ 					var r = fn();
+/******/ 					if (r !== undefined) result = r;
+/******/ 				}
+/******/ 			}
+/******/ 			return result;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/jsonp chunk loading */
+/******/ 	(() => {
+/******/ 		// no baseURI
+/******/ 		
+/******/ 		// object to store loaded and loading chunks
+/******/ 		// undefined = chunk not loaded, null = chunk preloaded/prefetched
+/******/ 		// [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
+/******/ 		var installedChunks = {
+/******/ 			"/public/editor": 0,
+/******/ 			"public/editor": 0
+/******/ 		};
+/******/ 		
+/******/ 		// no chunk on demand loading
+/******/ 		
+/******/ 		// no prefetching
+/******/ 		
+/******/ 		// no preloaded
+/******/ 		
+/******/ 		// no HMR
+/******/ 		
+/******/ 		// no HMR manifest
+/******/ 		
+/******/ 		__webpack_require__.O.j = (chunkId) => (installedChunks[chunkId] === 0);
+/******/ 		
+/******/ 		// install a JSONP callback for chunk loading
+/******/ 		var webpackJsonpCallback = (parentChunkLoadingFunction, data) => {
+/******/ 			var [chunkIds, moreModules, runtime] = data;
+/******/ 			// add "moreModules" to the modules object,
+/******/ 			// then flag all "chunkIds" as loaded and fire callback
+/******/ 			var moduleId, chunkId, i = 0;
+/******/ 			if(chunkIds.some((id) => (installedChunks[id] !== 0))) {
+/******/ 				for(moduleId in moreModules) {
+/******/ 					if(__webpack_require__.o(moreModules, moduleId)) {
+/******/ 						__webpack_require__.m[moduleId] = moreModules[moduleId];
+/******/ 					}
+/******/ 				}
+/******/ 				if(runtime) var result = runtime(__webpack_require__);
+/******/ 			}
+/******/ 			if(parentChunkLoadingFunction) parentChunkLoadingFunction(data);
+/******/ 			for(;i < chunkIds.length; i++) {
+/******/ 				chunkId = chunkIds[i];
+/******/ 				if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
+/******/ 					installedChunks[chunkId][0]();
+/******/ 				}
+/******/ 				installedChunks[chunkId] = 0;
+/******/ 			}
+/******/ 			return __webpack_require__.O(result);
+/******/ 		}
+/******/ 		
+/******/ 		var chunkLoadingGlobal = self["webpackChunk"] = self["webpackChunk"] || [];
+/******/ 		chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));
+/******/ 		chunkLoadingGlobal.push = webpackJsonpCallback.bind(null, chunkLoadingGlobal.push.bind(chunkLoadingGlobal));
+/******/ 	})();
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module depends on other loaded chunks and execution need to be delayed
+/******/ 	__webpack_require__.O(undefined, ["public/editor"], () => (__webpack_require__("./resources/js/editor.js")))
+/******/ 	var __webpack_exports__ = __webpack_require__.O(undefined, ["public/editor"], () => (__webpack_require__("./resources/css/editor.css")))
+/******/ 	__webpack_exports__ = __webpack_require__.O(__webpack_exports__);
+/******/ 	
+/******/ })()
+;

--- a/resources/js/editor.js
+++ b/resources/js/editor.js
@@ -91,6 +91,10 @@ window.dropblockeditor = (config) => {
 
             root.querySelectorAll('[drag-item]').forEach(el => {
                 el.addEventListener('click', e => {
+                    root.querySelectorAll('[drag-item]').forEach((preview) => preview.classList.remove('block-active'))
+                    let clickedBlock = e.target.closest('[drag-item]');
+                    clickedBlock.classList.add('block-active');
+
                     Livewire.dispatch('blockEditComponentSelected', {
                         blockId: e.target.closest('[drag-item]').dataset.block
                     });

--- a/src/Events/BlockClone.php
+++ b/src/Events/BlockClone.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jeffreyvr\DropBlockEditor\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class BlockClone
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(protected array $block = [])
+    {
+        //
+    }
+
+    public function setBlock(array $block): void
+    {
+        $this->block = $block;
+    }
+
+    public function getBlock(): array
+    {
+        return $this->block;
+    }
+}

--- a/src/Events/BlockCloned.php
+++ b/src/Events/BlockCloned.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jeffreyvr\DropBlockEditor\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class BlockCloned
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(protected array $block = [])
+    {
+        //
+    }
+
+    public function getBlock(): array
+    {
+        return $this->block;
+    }
+}

--- a/src/Events/BlockDeleted.php
+++ b/src/Events/BlockDeleted.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jeffreyvr\DropBlockEditor\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class BlockDeleted
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(protected array $block = [])
+    {
+        //
+    }
+
+    public function getBlock(): array
+    {
+        return $this->block;
+    }
+}

--- a/src/Events/BlockInsert.php
+++ b/src/Events/BlockInsert.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jeffreyvr\DropBlockEditor\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class BlockInsert
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(protected array $block = [])
+    {
+        //
+    }
+
+    public function setBlock(array $block): void
+    {
+        $this->block = $block;
+    }
+
+    public function getBlock(): array
+    {
+        return $this->block;
+    }
+}

--- a/src/Events/BlockInserted.php
+++ b/src/Events/BlockInserted.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jeffreyvr\DropBlockEditor\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class BlockInserted
+{
+    use Dispatchable;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(protected array $block = [])
+    {
+        //
+    }
+
+    public function getBlock(): array
+    {
+        return $this->block;
+    }
+}


### PR DESCRIPTION
See #39 

This PR adds support for Laravel events.

All events are conditional depending on availability of the dispatcher in the container, to avoid adding a package requirement.

This allows user code to hook into events and modify block data, or run arbitrary code at the time of inserting, cloning or deleting a block.